### PR TITLE
Restructure git version report

### DIFF
--- a/reports/git-versions.sh
+++ b/reports/git-versions.sh
@@ -36,7 +36,9 @@ execute << EOF
         uniq |
         perl -lape 's/[^ ]+ //' |
         grep -E '^git/' |
-        sort |
+        grep -v 'libgit2' |
+        perl -lape 's/(git\/\d+(?:\.\d+){0,2}).*$/\$1/' |
+        sort -r -V |
         uniq -c |
-        sort -n -r
+        awk '{printf("%s\t%s\n",\$2,\$1)}'
 EOF


### PR DESCRIPTION
This pull request restructures the git version report:

- patch/revision releases are aggregated into the corresponding minor version (for instance, `git/1.2.3.4-windows.2` is counted as `git/1.2.3`)
- git versions that are incorrectly reported by `libgit` are ignored
- minor formatting changes (see example below)

An exemplary output looks as follows:

```
git/2.14.1	320
git/2.14.0	11
git/2.13.4	1
git/2.13.3	35
git/2.13.2	15
git/2.13.1	34
git/2.13.0	37
git/2.12.3	1
git/2.12.2	43
git/2.12.1	8
git/2.12.0	28
git/2.11.2	1
git/2.11.1	60
git/2.11.0	442
git/2.10.2	41
git/2.10.1	116
git/2.10.0	41
git/2.9.4	2
git/2.9.3	19
git/2.9.2	178
git/2.9.0	14
git/2.8.6	1
git/2.8.4	8
git/2.8.3	14
git/2.8.2	10
git/2.8.1	166
git/2.8.0	2
```