### PR TITLE
Shorten versions in git version report

### DIFF
--- a/reports/git-versions.sh
+++ b/reports/git-versions.sh
@@ -37,7 +37,7 @@ execute << EOF
         perl -lape 's/[^ ]+ //' |
         grep -E '^git/' |
         grep -v 'libgit2' |
-        perl -lape 's/(git\/\d+(?:\.\d+){0,2}).*$/\$1/' |
+        perl -lape 's/git\/(\d+(?:\.\d+){0,2}).*$/\$1/' |
         sort -r -V |
         uniq -c |
         awk '{printf("%s\t%s\n",\$2,\$1)}'


### PR DESCRIPTION
This removes `git/` at the beginning of each version number in the git version report (as in `git/1.2.3`, which is now simply `1.2.3`), just to make processing the output slightly more convenient.