### PR TITLE
Fix branch protection with OSS forks

### DIFF
--- a/admin/oss-fork.sh
+++ b/admin/oss-fork.sh
@@ -103,13 +103,14 @@ pushd "$TEMP_REPO_PATH"
             RETRY_COUNT=0
             until ghe_api \
                     -X PUT \
-                    -H "Accept: application/vnd.github.loki-preview+json" \
+                    -H "Accept: application/vnd.github.luke-cage-preview+json" \
                     --data '{
                         "required_status_checks":null,
                         "restrictions": {
                             "users": ["'$OSS_FORK_UPDATE_USER'"], "teams": []
                         },
-                        "enforce_admins":true
+                        "enforce_admins":true,
+                        "required_pull_request_reviews":null
                     }' \
                     repos/$OSS_FORK_ORG/$TARGET_REPO_NAME/branches/$BRANCH_NAME/protection \
                     > /dev/null || (( RETRY_COUNT++ >= 5 ))


### PR DESCRIPTION
[GitHub updated the preview API to update the branch protection][1], which is used by the OSS forking script. For this reason, mirrored branches silently failed to be protected.

This adjusts for the changes in the preview API, namely by setting the required field `required_pull_request_reviews`.

[1]:https://developer.github.com/v3/repos/branches/#update-branch-protection